### PR TITLE
require tinymce-rails

### DIFF
--- a/lib/active_admin/tinymce/engine.rb
+++ b/lib/active_admin/tinymce/engine.rb
@@ -1,3 +1,5 @@
+require 'tinymce-rails'
+
 module ActiveAdmin
   module Tinymce
     class Engine < ::Rails::Engine


### PR DESCRIPTION
without requiring  tinymce-rails you need to include it into applications Gemfile 
or error occurs on `//=require tinymce` in active_admin.js

```
Sprockets::FileNotFound at /admin
couldn't find file 'tinymce'
  (in ....../app/assets/javascripts/active_admin.js.coffee:2
```
